### PR TITLE
Add input to specify windows architecture target to build vulkan-1.lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,16 +157,18 @@ jobs:
           arch: ${{ github.event.inputs.arch }}
 
       - name: resolve arch Win32 --> x86
-        id: archSolver
         shell: bash
-        env:
-          resolvedArch: x64
-        if: github.event.inputs.arch=='Win32'
-        run: resolvedArch='x86'
+        if: github.event.inputs.arch == 'Win32'
+        run: |
+          if [[ ${{ github.event.inputs.arch }} == 'Win32' ]] ; then
+            echo "resolvedArch=x86" >> $GITHUB_ENV
+          else
+            echo "resolvedArch=x64" >> $GITHUB_ENV
+          fi
         
       - uses: seanmiddleditch/gha-setup-vsdevenv@v4
         with:
-          arch: $archSolver.resolvedArch
+          arch: ${{ env.resolvedArch }}
       
       - name: Test Vulkan SDK Install
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,11 +156,10 @@ jobs:
           vulkan-use-cache: false
           arch: ${{ github.event.inputs.arch }}
 
-      - name: resolve arch Win32 --> x86
+      - name: resolve arch Win32 --> x86 if needed
         shell: bash
-        if: github.event.inputs.arch == 'Win32'
         run: |
-          if [[ ${{ github.event.inputs.arch }} == 'Win32' ]] ; then
+          if [[ ${{ inputs.arch }} == 'Win32' ]] ; then
             echo "resolvedArch=x86" >> $GITHUB_ENV
           else
             echo "resolvedArch=x64" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           vulkan-config-file: tests/vulkan_sdk_specs/linux.json
           vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
+          vulkan-use-cache: false
 
       - name: Test Vulkan SDK Install
         run: |
@@ -153,7 +153,7 @@ jobs:
         with:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
+          vulkan-use-cache: false
           arch: ${{ github.event.inputs.arch }}
 
       - uses: seanmiddleditch/gha-setup-vsdevenv@v4
@@ -180,7 +180,7 @@ jobs:
         with:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader, Glslang
-          vulkan-use-cache: true
+          vulkan-use-cache: false
       - name: Test Vulkan SDK Install
         run: |
           echo "Vulkan SDK Version=='$VULKAN_SDK_VERSION'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
   #         cmake --build tests/build --config release
   #         PATH=$PATH:$VULKAN_SDK/bin ./tests/build/test_vulkan
   # 
-  setup-windows-with-version-powershell:
+  setup-windows-with-arch:
     if: ${{ contains(github.event.inputs.extra_tests, 'default') }}
     runs-on: windows-latest
     steps:
@@ -156,11 +156,16 @@ jobs:
           vulkan-use-cache: false
           arch: ${{ github.event.inputs.arch }}
       
+        env:
+          resolvedArch: x64
+
+      - name: resolve arch Win32 --> x86
+        if: github.event.inputs.arch=='Win32'
+        run: $env.resolvedArch='x86'
+        
       - uses: seanmiddleditch/gha-setup-vsdevenv@v4
         with:
-          -arch: x64
-          if: ${{ github.event.inputs.arch=='Win32' }}
-          -arch: x86
+          -arch: $env.resolvedArch
       
       - name: Test Vulkan SDK Install
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,31 @@ jobs:
           $ENV:PATH="$ENV:PATH;$ENV:VULKAN_SDK/bin"
           tail -100 build/CMakeFiles/*.log
           ./build/test_vulkan
+
+  setup-windows-with-version-powershell-x86:
+    if: ${{ contains(github.event.inputs.extra_tests, 'default') }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        with:
+          vulkan-query-version: 1.3.204.0
+          vulkan-components: Vulkan-Headers, Vulkan-Loader
+          vulkan-use-cache: true
+          arch: x86
+
+      - uses: seanmiddleditch/gha-setup-vsdevenv@v4
+      - name: Test Vulkan SDK Install
+        shell: powershell
+        run: |
+          echo "Vulkan SDK Version=='$env:VULKAN_SDK_VERSION'"
+          if (!$env:VULKAN_SDK_VERSION) { throw "vulkan sdk install error" }
+          cd tests
+          cmake -G "Visual Studio 16 2019" -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
+          cmake --build build --config release
+          $ENV:PATH="$ENV:PATH;$ENV:VULKAN_SDK/bin"
+          tail -100 build/CMakeFiles/*.log
+          ./build/test_vulkan
   # 
   setup-macos-with-latest:
     if: ${{ contains(github.event.inputs.extra_tests, 'default') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
         extra_tests:
           description: 'Enable additional CI tests'
           required: false
-          default: false
+          default: "default"
         components:
           description: Vulkan SDK Components
           required: false
@@ -19,7 +19,7 @@ on:
         arch:
           description: Target architecture, Windows only (x64 or Win32)
           required: false
-          default: x64
+          default: Win32
 jobs:
   setup-all-matrix:
     if: ${{ github.event.inputs.extra_tests == 'true' || github.event.inputs.extra_tests == 'matrix' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,8 @@ jobs:
           arch: x86
 
       - uses: seanmiddleditch/gha-setup-vsdevenv@v4
+        with:
+          arch: ${{ ./inputs.arch }}
       - name: Test Vulkan SDK Install
         shell: powershell
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
         with:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
+          vulkan-use-cache: false
           arch: x86
 
       - uses: seanmiddleditch/gha-setup-vsdevenv@v4
@@ -195,7 +195,7 @@ jobs:
         with:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader, Glslang
-          vulkan-use-cache: true+
+          vulkan-use-cache: true
       - name: Test Vulkan SDK Install
         run: |
           echo "Vulkan SDK Version=='$VULKAN_SDK_VERSION'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ on:
           description: Vulkan SDK Version
           required: false
           default: latest
+        arch:
+          description: Target architecture (x64, x86)
+          required: false
+          default: x64
 jobs:
   setup-all-matrix:
     if: ${{ github.event.inputs.extra_tests == 'true' || github.event.inputs.extra_tests == 'matrix' }}
@@ -34,6 +38,8 @@ jobs:
           vulkan-query-version: ${{ github.event.inputs.version }}
           vulkan-components: ${{ github.event.inputs.components }}
           vulkan-use-cache: true
+          arch: ${{ github.event.inputs.arch }}
+
       - uses: seanmiddleditch/gha-setup-vsdevenv@v4
       - name: Test Vulkan SDK Install
         shell: bash
@@ -42,7 +48,7 @@ jobs:
           echo "VULKAN_SDK=='$VULKAN_SDK'"
           glslangValidator --version
           test -n "$VULKAN_SDK_VERSION"
-          cmake -B tests/build -S tests -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
+          cmake -A  ${{ github.event.inputs.arch }} -B tests/build -S tests -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
           cmake --build tests/build --config release
           ./tests/build/test_vulkan
   # 
@@ -81,13 +87,15 @@ jobs:
         with:
           vulkan-config-file: tests/vulkan_sdk_specs/linux.json
           vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true+
+          vulkan-use-cache: true
+          arch: ${{ github.event.inputs.arch }}
+
       - name: Test Vulkan SDK Install
         run: |
           echo "Vulkan SDK Version=='$VULKAN_SDK_VERSION'"
           echo "VULKAN_SDK=='$VULKAN_SDK'"
           test -n "$VULKAN_SDK_VERSION" || exit 4
-          cmake -B tests/build -S tests -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
+          cmake -A  ${{ github.event.inputs.arch }} -B tests/build -S tests -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
           cmake --build tests/build --config release -- -j2
           PATH=$PATH:$VULKAN_SDK/bin ./tests/build/test_vulkan
   # 
@@ -147,40 +155,18 @@ jobs:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader
           vulkan-use-cache: true
+          arch: ${{ github.event.inputs.arch }}
 
       - uses: seanmiddleditch/gha-setup-vsdevenv@v4
-      - name: Test Vulkan SDK Install
-        shell: powershell
-        run: |
-          echo "Vulkan SDK Version=='$env:VULKAN_SDK_VERSION'"
-          if (!$env:VULKAN_SDK_VERSION) { throw "vulkan sdk install error" }
-          cd tests
-          cmake -G "Visual Studio 17 2022" -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
-          cmake --build build --config release
-          $ENV:PATH="$ENV:PATH;$ENV:VULKAN_SDK/bin"
-          tail -100 build/CMakeFiles/*.log
-          ./build/test_vulkan
-
-  setup-windows-with-version-powershell-x86:
-    if: ${{ contains(github.event.inputs.extra_tests, 'default') }}
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./
         with:
-          vulkan-query-version: 1.3.204.0
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: false
-          arch: x86
-
-      - uses: seanmiddleditch/gha-setup-vsdevenv@v4
+          arch: ${{ github.event.inputs.arch }}
       - name: Test Vulkan SDK Install
         shell: powershell
         run: |
           echo "Vulkan SDK Version=='$env:VULKAN_SDK_VERSION'"
           if (!$env:VULKAN_SDK_VERSION) { throw "vulkan sdk install error" }
           cd tests
-          cmake -G "Visual Studio 17 2022" -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
+          cmake -A  ${{ github.event.inputs.arch }} -G "Visual Studio 17 2022" -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
           cmake --build build --config release
           $ENV:PATH="$ENV:PATH;$ENV:VULKAN_SDK/bin"
           tail -100 build/CMakeFiles/*.log
@@ -201,7 +187,7 @@ jobs:
           echo "Vulkan SDK Version=='$VULKAN_SDK_VERSION'"
           echo "VULKAN_SDK=='$VULKAN_SDK'"
           test -n "$VULKAN_SDK_VERSION"
-          cmake -B tests/build -S tests -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
+          cmake -A  ${{ github.event.inputs.arch }} -B tests/build -S tests -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
           cmake --build tests/build --config release -- -j2
           glslangValidator --version
           PATH=$PATH:$VULKAN_SDK/bin ./tests/build/test_vulkan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,13 @@ jobs:
           echo "Vulkan SDK Version=='$env:VULKAN_SDK_VERSION'"
           if (!$env:VULKAN_SDK_VERSION) { throw "vulkan sdk install error" }
           cd tests
-          cmake -A  ${{ github.event.inputs.arch }} -G "Visual Studio 17 2022" -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
+
+          arch=x64
+          if ${{ inputs.arch }}==x86 ; then
+            arch=Win32
+          fi
+
+          cmake -A $arch -G "Visual Studio 17 2022" -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
           cmake --build build --config release
           $ENV:PATH="$ENV:PATH;$ENV:VULKAN_SDK/bin"
           tail -100 build/CMakeFiles/*.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
         extra_tests:
           description: 'Enable additional CI tests'
           required: false
-          default: "default"
+          default: false
         components:
           description: Vulkan SDK Components
           required: false
@@ -17,7 +17,7 @@ on:
           required: false
           default: latest
         arch:
-          description: Target architecture, Windows only (x64 or Win32)
+          description: Windows only, Target architecture (x64 or Win32)
           required: false
           default: Win32
 jobs:
@@ -38,8 +38,6 @@ jobs:
           vulkan-query-version: ${{ github.event.inputs.version }}
           vulkan-components: ${{ github.event.inputs.components }}
           vulkan-use-cache: true
-          arch: ${{ github.event.inputs.arch }}
-
       - uses: seanmiddleditch/gha-setup-vsdevenv@v4
       - name: Test Vulkan SDK Install
         shell: bash
@@ -87,8 +85,7 @@ jobs:
         with:
           vulkan-config-file: tests/vulkan_sdk_specs/linux.json
           vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: false
-
+          vulkan-use-cache: true
       - name: Test Vulkan SDK Install
         run: |
           echo "Vulkan SDK Version=='$VULKAN_SDK_VERSION'"
@@ -177,9 +174,7 @@ jobs:
             echo "vulkan sdk install error"
             exit 1
           fi
-
           cd tests
-
           cmake -A ${{ inputs.arch }} -G "Visual Studio 17 2022" -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
           cmake --build build --config release
           PATH="$PATH:$VULKAN_SDK/bin"
@@ -194,7 +189,7 @@ jobs:
         with:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader, Glslang
-          vulkan-use-cache: false
+          vulkan-use-cache: true
       - name: Test Vulkan SDK Install
         run: |
           echo "Vulkan SDK Version=='$VULKAN_SDK_VERSION'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,8 +174,6 @@ jobs:
           arch: x86
 
       - uses: seanmiddleditch/gha-setup-vsdevenv@v4
-        with:
-          arch: ${{ ./inputs.arch }}
       - name: Test Vulkan SDK Install
         shell: powershell
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
           required: false
           default: latest
         arch:
-          description: Target architecture (x64, x86)
+          description: Target architecture, Windows only (x64 or Win32)
           required: false
           default: x64
 jobs:
@@ -157,11 +157,9 @@ jobs:
           arch: ${{ github.event.inputs.arch }}
       
       - uses: seanmiddleditch/gha-setup-vsdevenv@v4
-        if: ${{ contains(github.event.inputs.arch, 'x64') }}
         with:
           -arch: x64
-        if: ${{ contains(github.event.inputs.arch, 'Win32') }}
-        with:
+          if: ${{ github.event.inputs.arch=='Win32' }}
           -arch: x86
       
       - name: Test Vulkan SDK Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
           echo "Vulkan SDK Version=='$env:VULKAN_SDK_VERSION'"
           if (!$env:VULKAN_SDK_VERSION) { throw "vulkan sdk install error" }
           cd tests
-          cmake -G "Visual Studio 16 2019" -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
+          cmake -G "Visual Studio 17 2022" -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
           cmake --build build --config release
           $ENV:PATH="$ENV:PATH;$ENV:VULKAN_SDK/bin"
           tail -100 build/CMakeFiles/*.log
@@ -180,7 +180,7 @@ jobs:
           echo "Vulkan SDK Version=='$env:VULKAN_SDK_VERSION'"
           if (!$env:VULKAN_SDK_VERSION) { throw "vulkan sdk install error" }
           cd tests
-          cmake -G "Visual Studio 16 2019" -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
+          cmake -G "Visual Studio 17 2022" -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
           cmake --build build --config release
           $ENV:PATH="$ENV:PATH;$ENV:VULKAN_SDK/bin"
           tail -100 build/CMakeFiles/*.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,17 +155,18 @@ jobs:
           vulkan-components: Vulkan-Headers, Vulkan-Loader
           vulkan-use-cache: false
           arch: ${{ github.event.inputs.arch }}
-      
-        env:
-          resolvedArch: x64
 
       - name: resolve arch Win32 --> x86
+        id: archSolver
+        shell: bash
+        env:
+          resolvedArch: x64
         if: github.event.inputs.arch=='Win32'
-        run: $env.resolvedArch='x86'
+        run: resolvedArch='x86'
         
       - uses: seanmiddleditch/gha-setup-vsdevenv@v4
         with:
-          -arch: $env.resolvedArch
+          arch: $archSolver.resolvedArch
       
       - name: Test Vulkan SDK Install
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,20 +160,24 @@ jobs:
         with:
           arch: ${{ github.event.inputs.arch }}
       - name: Test Vulkan SDK Install
-        shell: powershell
+        shell: bash
         run: |
-          echo "Vulkan SDK Version=='$env:VULKAN_SDK_VERSION'"
-          if (!$env:VULKAN_SDK_VERSION) { throw "vulkan sdk install error" }
+          echo "Vulkan SDK Version==$VULKAN_SDK_VERSION"
+          if [[ -z "$VULKAN_SDK_VERSION" ]] ; then
+            echo "vulkan sdk install error"
+            exit 1
+          fi
+
           cd tests
 
           arch=x64
-          if ("${{ inputs.arch }}" -eq "x86"){
+          if [[ ${{ inputs.arch }}==x86 ]] ; then
             arch=Win32
-          }
+          fi
+
           cmake -A $arch -G "Visual Studio 17 2022" -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
           cmake --build build --config release
-          $ENV:PATH="$ENV:PATH;$ENV:VULKAN_SDK/bin"
-          tail -100 build/CMakeFiles/*.log
+          PATH="$PATH:$VULKAN_SDK/bin"
           ./build/test_vulkan
   # 
   setup-macos-with-latest:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           echo "VULKAN_SDK=='$VULKAN_SDK'"
           glslangValidator --version
           test -n "$VULKAN_SDK_VERSION"
-          cmake -A  ${{ github.event.inputs.arch }} -B tests/build -S tests -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
+          cmake -B tests/build -S tests -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
           cmake --build tests/build --config release
           ./tests/build/test_vulkan
   # 
@@ -88,14 +88,13 @@ jobs:
           vulkan-config-file: tests/vulkan_sdk_specs/linux.json
           vulkan-components: Vulkan-Headers, Vulkan-Loader
           vulkan-use-cache: true
-          arch: ${{ github.event.inputs.arch }}
 
       - name: Test Vulkan SDK Install
         run: |
           echo "Vulkan SDK Version=='$VULKAN_SDK_VERSION'"
           echo "VULKAN_SDK=='$VULKAN_SDK'"
           test -n "$VULKAN_SDK_VERSION" || exit 4
-          cmake -A  ${{ github.event.inputs.arch }} -B tests/build -S tests -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
+          cmake -B tests/build -S tests -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
           cmake --build tests/build --config release -- -j2
           PATH=$PATH:$VULKAN_SDK/bin ./tests/build/test_vulkan
   # 
@@ -187,7 +186,7 @@ jobs:
           echo "Vulkan SDK Version=='$VULKAN_SDK_VERSION'"
           echo "VULKAN_SDK=='$VULKAN_SDK'"
           test -n "$VULKAN_SDK_VERSION"
-          cmake -A  ${{ github.event.inputs.arch }} -B tests/build -S tests -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
+          cmake -B tests/build -S tests -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
           cmake --build tests/build --config release -- -j2
           glslangValidator --version
           PATH=$PATH:$VULKAN_SDK/bin ./tests/build/test_vulkan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
           cd tests
 
           arch=x64
-          if ${{ inputs.arch }}==x86 ; then
+          if [[ ${{ inputs.arch }}==x86 ]] ; then
             arch=Win32
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,10 +155,15 @@ jobs:
           vulkan-components: Vulkan-Headers, Vulkan-Loader
           vulkan-use-cache: false
           arch: ${{ github.event.inputs.arch }}
-
+      
       - uses: seanmiddleditch/gha-setup-vsdevenv@v4
+        if: ${{ contains(github.event.inputs.arch, 'x64') }}
         with:
-          arch: ${{ github.event.inputs.arch }}
+          -arch: x64
+        if: ${{ contains(github.event.inputs.arch, 'Win32') }}
+        with:
+          -arch: x86
+      
       - name: Test Vulkan SDK Install
         shell: bash
         run: |
@@ -170,12 +175,7 @@ jobs:
 
           cd tests
 
-          arch=x64
-          if [[ ${{ inputs.arch }}==x86 ]] ; then
-            arch=Win32
-          fi
-
-          cmake -A $arch -G "Visual Studio 17 2022" -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
+          cmake -A ${{ inputs.arch }} -G "Visual Studio 17 2022" -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
           cmake --build build --config release
           PATH="$PATH:$VULKAN_SDK/bin"
           ./build/test_vulkan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,10 +167,9 @@ jobs:
           cd tests
 
           arch=x64
-          if [[ ${{ inputs.arch }}==x86 ]] ; then
+          if ("${{ inputs.arch }}" -eq "x86"){
             arch=Win32
-          fi
-
+          }
           cmake -A $arch -G "Visual Studio 17 2022" -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
           cmake --build build --config release
           $ENV:PATH="$ENV:PATH;$ENV:VULKAN_SDK/bin"

--- a/action.yml
+++ b/action.yml
@@ -97,24 +97,29 @@ runs:
       shell: vsdevenv ${{ inputs.arch }} bash {0}
       run: |
         # cmake configure
-        set -a
-        . $PWD/_vulkan_build/env
-        if [[ $RUNNER_OS == 'Windows' ]] ; then
-          CC=cl.exe
-          CXX=cl.exe
-        fi
 
         arch=x64
         if ${{ inputs.arch }}==x86 ; then
           arch=Win32
         fi
+
+        set -a
+        . $PWD/_vulkan_build/env
+
+        param="-S $GITHUB_ACTION_PATH -B ${VULKAN_SDK_BUILD_DIR} \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DVULKAN_SDK=${VULKAN_SDK} \
+                -DVULKAN_SDK_CONFIG="${VULKAN_SDK_CONFIG_FILE}" \
+                -DVULKAN_SDK_COMPONENTS="${VULKAN_SDK_COMPONENTS}" \
+        || { cat _vulkan_build/CMakeFiles/*.log ; exit 4 ; }"
+
+        if [[ $RUNNER_OS == 'Windows' ]] ; then
+          CC=cl.exe
+          CXX=cl.exe
+          param=-A $arch $param
+        fi
         
-        cmake -A $arch -S $GITHUB_ACTION_PATH -B ${VULKAN_SDK_BUILD_DIR} \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DVULKAN_SDK=${VULKAN_SDK} \
-          -DVULKAN_SDK_CONFIG="${VULKAN_SDK_CONFIG_FILE}" \
-          -DVULKAN_SDK_COMPONENTS="${VULKAN_SDK_COMPONENTS}" \
-        || { cat _vulkan_build/CMakeFiles/*.log ; exit 4 ; }
+        cmake $param
 
     - name: Build Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'

--- a/action.yml
+++ b/action.yml
@@ -103,6 +103,8 @@ runs:
           echo "Is Windows: true"
           if [[ ${{ inputs.arch }} == 'Win32' ]] ; then
             echo "resolvedArch=x86" >> $GITHUB_ENV
+          else
+            echo "resolvedArch=x64" >> $GITHUB_ENV
           fi
         else
           echo "resolvedArch=x64" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,11 @@ runs:
 
     - name: Configure Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'
-      shell: vsdevenv ${{ inputs.arch }} bash {0}
+      shell: |
+          arch=x64
+          if [[ ${{ inputs.arch }}==Win32 ]] ; then
+            arch=x86
+          fi | vsdevenv $arch bash {0}
       run: |
         # cmake configure
         set -a
@@ -104,12 +108,7 @@ runs:
         if [[ $RUNNER_OS == 'Windows' ]] ; then
           CC=cl.exe
           CXX=cl.exe
-
-          arch=x64
-          if [[ ${{ inputs.arch }}==x86 ]] ; then
-            arch=Win32
-          fi
-          archParam="-A ${arch}"
+          archParam="-A ${{ inputs.arch }}"
         fi
 
         echo $archParam
@@ -122,7 +121,11 @@ runs:
 
     - name: Build Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'
-      shell: vsdevenv ${{ inputs.arch }} bash {0}
+      shell: |
+          arch=x64
+          if [[ ${{ inputs.arch }}==Win32 ]] ; then
+            arch=x86
+          fi | vsdevenv $arch bash {0}
       run: |
         # cmake build
         set -a

--- a/action.yml
+++ b/action.yml
@@ -97,29 +97,28 @@ runs:
       shell: vsdevenv ${{ inputs.arch }} bash {0}
       run: |
         # cmake configure
-
-        arch=x64
-        if ${{ inputs.arch }}==x86 ; then
-          arch=Win32
-        fi
-
         set -a
         . $PWD/_vulkan_build/env
 
-        param="-S $GITHUB_ACTION_PATH -B ${VULKAN_SDK_BUILD_DIR} \
+        archParam=""
+        if [[ $RUNNER_OS == 'Windows' ]] ; then
+          CC=cl.exe
+          CXX=cl.exe
+
+          arch=x64
+          if [[ ${{ inputs.arch }}==x86 ]] ; then
+            arch=Win32
+          fi
+          archParam="-A ${arch}"
+        fi
+
+        echo $archParam
+        cmake ${archParam} -S $GITHUB_ACTION_PATH -B ${VULKAN_SDK_BUILD_DIR} \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DVULKAN_SDK=${VULKAN_SDK} \
                 -DVULKAN_SDK_CONFIG="${VULKAN_SDK_CONFIG_FILE}" \
                 -DVULKAN_SDK_COMPONENTS="${VULKAN_SDK_COMPONENTS}" \
-        || { cat _vulkan_build/CMakeFiles/*.log ; exit 4 ; }"
-
-        if [[ $RUNNER_OS == 'Windows' ]] ; then
-          CC=cl.exe
-          CXX=cl.exe
-          param=-A $arch $param
-        fi
-        
-        cmake $param
+                || { cat _vulkan_build/CMakeFiles/*.log ; exit 4 ; }
 
     - name: Build Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'

--- a/action.yml
+++ b/action.yml
@@ -96,23 +96,21 @@ runs:
     - name: resolve arch
       id: archSolver
       shell: bash
-      env:
-        resolvedArch: x64
-      if: runner.os == 'Windows' && github.event.inputs.arch == 'Win32'
       run: |
         #  resolve arch for vsdenv when cmake arch is Win32 (WINDOWS ONLY)
+        
         if [[ $RUNNER_OS == 'Windows' ]] ; then
           echo "Is Windows: true"
+          if [[ ${{ github.event.inputs.arch }} == 'Win32' ]] ; then
+            echo "resolvedArch=x86" >> $GITHUB_ENV
+          fi
         else
-          echo "Is Windows: true"
+          echo "resolvedArch=x64" >> $GITHUB_ENV
         fi
-        echo "resolvedArch before: ${resolvedArch}"
-        resolvedArch="x86"
-        echo "resolvedArch after: ${resolvedArch}"
 
     - name: Configure Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'
-      shell: vsdevenv ${{ steps[archSolver].resolvedArch }} bash {0}
+      shell: vsdevenv ${{ env.resolvedArch }} bash {0}
       run: |
         # cmake configure
         set -a
@@ -135,7 +133,7 @@ runs:
 
     - name: Build Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'
-      shell: vsdevenv ${{ archSolver.resolvedArch }} bash {0}
+      shell: vsdevenv ${{ env.resolvedArch }} bash {0}
       run: |
         # cmake build
         set -a

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,7 @@ inputs:
     required: false
 runs:
   using: "composite"
+
   steps: 
     - uses: humbletim/vsdevenv-shell@e87fcf2359929606ba32db358baef5ede4737aed
 
@@ -92,12 +93,11 @@ runs:
         cat $VULKAN_SDK_BUILD_DIR/env
         echo "--------------------------------------------------------------"
 
-    env:
-      resolvedArch: x64
-
     - name: resolve arch Win32 --> x86
+      env:
+        resolvedArch: x64
       if: github.event.inputs.arch=='Win32'
-      run: $env.resolvedArch='x86'
+      run: $resolvedArch='x86'
 
     - name: Configure Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ runs:
 
     - name: Configure Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'
-      shell: vsdevenv "${{ inputs.cmake-arch-target }}" bash {0}
+      shell: vsdevenv "${{ inputs.arch }}" bash {0}
       run: |
         # cmake configure
         set -a
@@ -112,7 +112,7 @@ runs:
 
     - name: Build Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'
-      shell: vsdevenv "${{ inputs.cmake-arch-target }}" bash {0}
+      shell: vsdevenv "${{ inputs.arch }}" bash {0}
       run: |
         # cmake build
         set -a

--- a/action.yml
+++ b/action.yml
@@ -94,10 +94,9 @@ runs:
         echo "--------------------------------------------------------------"
 
     - name: resolve arch
-      id: archSolver
       shell: bash
       run: |
-        #  resolve arch for vsdenv when cmake arch is Win32 (WINDOWS ONLY)
+        #  resolve arch to x86 for vsdenv when cmake arch target is Win32 (WINDOWS ONLY); x64 for everything else
         
         if [[ $RUNNER_OS == 'Windows' ]] ; then
           echo "Is Windows: true"
@@ -124,14 +123,13 @@ runs:
           CXX=cl.exe
           archParam="-A ${{ inputs.arch }}"
         fi
-
-        echo $archParam
+        
         cmake ${archParam} -S $GITHUB_ACTION_PATH -B ${VULKAN_SDK_BUILD_DIR} \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DVULKAN_SDK=${VULKAN_SDK} \
-                -DVULKAN_SDK_CONFIG="${VULKAN_SDK_CONFIG_FILE}" \
-                -DVULKAN_SDK_COMPONENTS="${VULKAN_SDK_COMPONENTS}" \
-                || { cat _vulkan_build/CMakeFiles/*.log ; exit 4 ; }
+        -DCMAKE_BUILD_TYPE=Release \
+        -DVULKAN_SDK=${VULKAN_SDK} \
+        -DVULKAN_SDK_CONFIG="${VULKAN_SDK_CONFIG_FILE}" \
+        -DVULKAN_SDK_COMPONENTS="${VULKAN_SDK_COMPONENTS}" \
+        || { cat _vulkan_build/CMakeFiles/*.log ; exit 4 ; }
 
     - name: Build Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'

--- a/action.yml
+++ b/action.yml
@@ -94,6 +94,7 @@ runs:
         echo "--------------------------------------------------------------"
 
     - name: resolve arch
+      id: archSolver
       shell: bash
       env:
         resolvedArch: x64
@@ -111,7 +112,7 @@ runs:
 
     - name: Configure Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'
-      shell: vsdevenv $resolvedArch bash {0}
+      shell: vsdevenv ${{ steps[archSolver].resolvedArch }} bash {0}
       run: |
         # cmake configure
         set -a
@@ -134,7 +135,7 @@ runs:
 
     - name: Build Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'
-      shell: vsdevenv $resolvedArch bash {0}
+      shell: vsdevenv ${{ archSolver.resolvedArch }} bash {0}
       run: |
         # cmake build
         set -a

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ runs:
 
     - name: Configure Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'
-      shell: vsdevenv "${{ inputs.arch }}" bash {0}
+      shell: vsdevenv ${{ inputs.arch }} bash {0}
       run: |
         # cmake configure
         set -a
@@ -112,7 +112,7 @@ runs:
 
     - name: Build Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'
-      shell: vsdevenv "${{ inputs.arch }}" bash {0}
+      shell: vsdevenv ${{ inputs.arch }} bash {0}
       run: |
         # cmake build
         set -a

--- a/action.yml
+++ b/action.yml
@@ -93,13 +93,18 @@ runs:
         cat $VULKAN_SDK_BUILD_DIR/env
         echo "--------------------------------------------------------------"
 
-    - name: resolve arch Win32 --> x86
+    - name: resolve arch
       shell: bash
       env:
         resolvedArch: x64
-      if: github.event.inputs.arch=='Win32'
+      if: runner.os == 'Windows' && github.event.inputs.arch == 'Win32'
       run: |
-        #  resolve arch Win32 --> x86
+        #  resolve arch for vsdenv when cmake arch is Win32 (WINDOWS ONLY)
+        if [[ $RUNNER_OS == 'Windows' ]] ; then
+          echo "Is Windows: true"
+        else
+          echo "Is Windows: true"
+        fi
         echo "resolvedArch before: ${resolvedArch}"
         resolvedArch="x86"
         echo "resolvedArch after: ${resolvedArch}"

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     default: false
     required: false
   arch:
-    description: 'Build architecture'
+    description: 'Build architecture, Windows only (x64 or Win32)'
     default: x64
     required: false
 runs:
@@ -98,7 +98,8 @@ runs:
           arch=x64
           if [[ ${{ inputs.arch }}==Win32 ]] ; then
             arch=x86
-          fi | vsdevenv $arch bash {0}
+          fi
+          vsdevenv $arch bash {0}
       run: |
         # cmake configure
         set -a

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,11 @@ runs:
       env:
         resolvedArch: x64
       if: github.event.inputs.arch=='Win32'
-      run: $resolvedArch="x86"
+      run: |
+        #  resolve arch Win32 --> x86
+        echo "resolvedArch before: ${resolvedArch}"
+        resolvedArch="x86"
+        echo "resolvedArch after: ${resolvedArch}"
 
     - name: Configure Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'

--- a/action.yml
+++ b/action.yml
@@ -103,7 +103,13 @@ runs:
           CC=cl.exe
           CXX=cl.exe
         fi
-        cmake -A ${{ inputs.arch }} -S $GITHUB_ACTION_PATH -B ${VULKAN_SDK_BUILD_DIR} \
+
+        arch=x64
+        if ${{ inputs.arch }}==x86 ; then
+          arch=Win32
+        fi
+        
+        cmake -A $arch -S $GITHUB_ACTION_PATH -B ${VULKAN_SDK_BUILD_DIR} \
           -DCMAKE_BUILD_TYPE=Release \
           -DVULKAN_SDK=${VULKAN_SDK} \
           -DVULKAN_SDK_CONFIG="${VULKAN_SDK_CONFIG_FILE}" \

--- a/action.yml
+++ b/action.yml
@@ -101,7 +101,7 @@ runs:
         
         if [[ $RUNNER_OS == 'Windows' ]] ; then
           echo "Is Windows: true"
-          if [[ ${{ github.event.inputs.arch }} == 'Win32' ]] ; then
+          if [[ ${{ inputs.arch }} == 'Win32' ]] ; then
             echo "resolvedArch=x86" >> $GITHUB_ENV
           fi
         else

--- a/action.yml
+++ b/action.yml
@@ -92,14 +92,16 @@ runs:
         cat $VULKAN_SDK_BUILD_DIR/env
         echo "--------------------------------------------------------------"
 
+    env:
+      resolvedArch: x64
+
+    - name: resolve arch Win32 --> x86
+      if: github.event.inputs.arch=='Win32'
+      run: $env.resolvedArch='x86'
+
     - name: Configure Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'
-      shell: |
-          arch=x64
-          if [[ ${{ inputs.arch }}==Win32 ]] ; then
-            arch=x86
-          fi
-          vsdevenv $arch bash {0}
+      shell: vsdevenv $resolvedArch bash {0}
       run: |
         # cmake configure
         set -a
@@ -122,11 +124,7 @@ runs:
 
     - name: Build Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'
-      shell: |
-          arch=x64
-          if [[ ${{ inputs.arch }}==Win32 ]] ; then
-            arch=x86
-          fi | vsdevenv $arch bash {0}
+      shell: vsdevenv $resolvedArch bash {0}
       run: |
         # cmake build
         set -a

--- a/action.yml
+++ b/action.yml
@@ -94,10 +94,11 @@ runs:
         echo "--------------------------------------------------------------"
 
     - name: resolve arch Win32 --> x86
+      shell: bash
       env:
         resolvedArch: x64
       if: github.event.inputs.arch=='Win32'
-      run: $resolvedArch='x86'
+      run: $resolvedArch="x86"
 
     - name: Configure Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'

--- a/action.yml
+++ b/action.yml
@@ -103,7 +103,7 @@ runs:
           CC=cl.exe
           CXX=cl.exe
         fi
-        cmake -S $GITHUB_ACTION_PATH -B ${VULKAN_SDK_BUILD_DIR} \
+        cmake -A ${{ inputs.arch }} -S $GITHUB_ACTION_PATH -B ${VULKAN_SDK_BUILD_DIR} \
           -DCMAKE_BUILD_TYPE=Release \
           -DVULKAN_SDK=${VULKAN_SDK} \
           -DVULKAN_SDK_CONFIG="${VULKAN_SDK_CONFIG_FILE}" \

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'specify whether to cache VULKAN_SDK/ results between runs (using github actions/cache)'
     default: false
     required: false
+  arch:
+    description: 'Build architecture'
+    default: x64
+    required: false
 runs:
   using: "composite"
   steps: 
@@ -90,7 +94,7 @@ runs:
 
     - name: Configure Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'
-      shell: vsdevenv x64 bash {0}
+      shell: vsdevenv "${{ inputs.cmake-arch-target }}" bash {0}
       run: |
         # cmake configure
         set -a
@@ -108,7 +112,7 @@ runs:
 
     - name: Build Vulkan SDK Components
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'
-      shell: vsdevenv x64 bash {0}
+      shell: vsdevenv "${{ inputs.cmake-arch-target }}" bash {0}
       run: |
         # cmake build
         set -a


### PR DESCRIPTION
Hello,

I know it's probably a minor set of the users but I needed to make sure that my project using  Vulkan would also compile for Win32. This didn't seem to be covered by your action as I understood everything was set to x64 by default; I hope I didn't miss anything. If you think it's too specific, feel free to leave it pending. At least, I wanted to share my solution for the few people that might be interested.

I added an optional input to be able to select x64 or Win32 with a description mentioning that this is relevant for windows only. Then, there is a catch: vsdevenv can be set with x86 but not Win32, so I added a step in the action to translate the arch to x86 in the only case that user want to set up vulkan for Win32.

The windows test for powershell was replaced with a test including the arch.

P.S. I am sorry, the intermediate tests were a bit messy and I didn't know about action-tmate until 10min ago...