### PR TITLE
[wip] v1.2.1 staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# setup-vulkan-sdk v1.2.0
+# setup-vulkan-sdk v1.2.1
 
 [![test setup-vulkan-sdk](https://github.com/humbletim/setup-vulkan-sdk/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/humbletim/setup-vulkan-sdk/actions/workflows/ci.yml)
 
@@ -14,22 +14,20 @@ _note: if new to GitHub Actions please see GitHub Help Documentation [Quickstart
 
 ```yaml
   -name: Prepare Vulkan SDK
-   uses: humbletim/setup-vulkan-sdk@v1.2.0
+   uses: humbletim/setup-vulkan-sdk@v1.2.1
    with:
-     vulkan-query-version: 1.3.204.0
+     vulkan-query-version: 1.3.275.0
      vulkan-components: Vulkan-Headers, Vulkan-Loader
      vulkan-use-cache: true
 ```
 
 SDK version numbers are resolved into corresponding Khronos repos and commit points using the official LunarG [SDK web API](https://vulkan.lunarg.com/content/view/latest-sdk-version-api).
 
-As of now the following SDK release numbers are known to be usable across all three primary platforms (linux/mac/windows):
-- 1.2.162.0
-- 1.2.162.1
-- 1.2.170.0
-- 1.2.189.0
-- 1.2.198.1
-- 1.3.204.0
+Example SDK release numbers that are <span title="2024-02-08">currently</span> known to be usable across all three primary platforms (linux/mac/windows):
+ - 1.2.198.1
+ - 1.3.204.1
+ - 1.3.239.0
+ - 1.3.275.0
 
 It is also possible to specify `latest` and the action will attempt to resolve automatically.
 
@@ -43,7 +41,7 @@ However, depending on your project's needs, it might make more sense to use unat
 
 ## Action Parameters
 
-- **`vulkan-query-version`**: valid SDK release number (eg: `1.2.161.1` or `latest`). *[required]*
+- **`vulkan-query-version`**: valid SDK release number (eg: `1.3.275.0` or `latest`). *[required]*
 - **`vulkan-config-file`**: project-local config.json file path. *[optional; default: '']*
   - note: config.json files already contain versioning info, so when specified vulkan-query-version will be ignored
 - **`vulkan-use-cache`**: if `true` the VULKAN_SDK folder is cached and restored across builds. *[optional; default=false]*
@@ -65,10 +63,10 @@ However, depending on your project's needs, it might make more sense to use unat
   - name: Fetch Vulkan SDK version spec
     shell: bash
     run: |
-      curl -o vulkan-sdk-config.json https://vulkan.lunarg.com/sdk/config/1.3.204.0/linux/config.json
+      curl -o vulkan-sdk-config.json https://vulkan.lunarg.com/sdk/config/1.3.224.1/linux/config.json
 
   - name: Configure Vulkan SDK using the downloaded spec
-    uses: humbletim/setup-vulkan-sdk@v1.2.0
+    uses: humbletim/setup-vulkan-sdk@v1.2.1
     with:
       vulkan-config-file: vulkan-sdk-config.json
       vulkan-components: Vulkan-Headers, Vulkan-Loader


### PR DESCRIPTION
Holding off on stamping a `v1.2.1` official release pending further investigation into the emergent #19 legacy version Mac build failures.

Note: that latest round of *node.js deprecation warnings* have been merged into `main`. 

<details><summary>For those in a hurry it is possible to adopt those changes using a commit point instead of version.</summary>
`main` at time of writing resolves into:

- humbletim/setup-vulkan-sdk@523828e49cd4afabce369c39c7ee6543a2b7a735

```yaml
  uses: humbletim/setup-vulkan-sdk@523828e49cd4afabce369c39c7ee6543a2b7a735
```

</details>

cc: 
- #12
- #19 
- #20 