### PR TITLE
Improve cache for architectures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Setup
 on:
   push:
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
       inputs:
         extra_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ on:
         oses:
           description: 'Matrix OSes'
           required: true
-          default: '[ "ubuntu-latest", "windows-latest", "windows-2022", "macos-12" ]'
+          default: '[ "ubuntu-latest", "windows-latest", "windows-2022", "macos-13", "macos-14" ]'
 jobs:
   setup-all-matrix:
     if: ${{ github.event.inputs.extra_tests == 'true' || github.event.inputs.extra_tests == 'matrix' }}
@@ -35,6 +35,9 @@ jobs:
           vulkan-query-version: ${{ matrix.version }}
           vulkan-components: ${{ github.event.inputs.components }}
           vulkan-use-cache: true
+      - name: Print runner configurations
+        run: |
+          echo runner os: ${{ runner.os }}, arch: ${{ runner.arch }}
       - name: checkout seanmiddleditch/gha-setup-vsdevenv@v4
         if: runner.os == 'Windows'
         uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: VULKAN_SDK
-        key: ${{ runner.os }}-vulkan-cached-sdk-${{ hashFiles('_vulkan_build/cache-key.txt') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-vulkan-cached-sdk-${{ hashFiles('_vulkan_build/cache-key.txt') }}
 
     - name: Configure Vulkan SDK Build Prerequisites
       if: steps.vulkan-cached-sdk.outputs.cache-hit != 'true'


### PR DESCRIPTION
Users might use this action to prepare multiple jobs
with the same OS but different architectures, for example,
macOS' x86_64 and arm64, Linux's x86_64 and arm64 and even
Windows x86_64 and arm64.

This CL just add architecture information of runner
to make cache workable for this special scenario.
